### PR TITLE
Make fix PR title feature work

### DIFF
--- a/lib/bot.rb
+++ b/lib/bot.rb
@@ -107,10 +107,10 @@ class Bot
   end
 
   def pr_name_ticket_id_regex
-    /\A\[#{@jira_configuration.project_key}-(\d+)\]/
+    /\A\[#{@jira_configuration.project_key}-(\d+)\]/i
   end
 
   def branch_name_ticket_id_regex
-    /\A\w+\/#{@jira_configuration.project_key}-(\d+)/
+    /\A\w+\/#{@jira_configuration.project_key} (\d+)/i
   end
 end


### PR DESCRIPTION
This PR fixes the feature that implements renaming of PRs that get created with a name based on the branch name to our desired pattern: `Feature/bt 30 test pr name` gets renamed to `[BT-30] Test PR name`

[BT-30]: https://liefery.atlassian.net/browse/BT-30