### PR TITLE
[LIEF-15874] Automatically add Jira issues for Depfu PRs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,6 +13,9 @@ export COMMENT_ID = 394743972
 # export COMMENT_BODY = ""
 # export COMMENT_ID = ""
 
+# Test PR labels
+# export PR_LABELS = '["depfu","enhancement","question"]'
+
 # email instead of username is required
 export JIRA_USER = "XXX@liefery.com"
 # this is an auth token that can be generated via

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 gem "jira-ruby"
 gem "octokit"
 gem "dotenv"
+gem "activesupport"
 
 group :development do
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   dotenv
   jira-ruby
   octokit

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ First you need a place for the bot to run. We at Liefery use Jenkins for this.
     * `PR_NUMBER` => `$.issue.number`
     * `COMMENT_ID` => `$.comment.id`
     * `COMMENT_BODY` => `$.comment.body`
+    * `PR_LABELS` => `$.pull_request.labels[*].name`
   * Select `Print post content`
   * Select `Print contributed variables`
 * Add an `Execute shell` build step for Build:

--- a/lib/run.rb
+++ b/lib/run.rb
@@ -10,7 +10,7 @@ require "configuration/jira"
 
 def get_array_from_env(key)
   JSON.parse(ENV[key])
-rescue TypeError
+rescue TypeError, JSON::ParserError
   []
 end
 

--- a/lib/run.rb
+++ b/lib/run.rb
@@ -9,7 +9,9 @@ require "bot"
 require "configuration/jira"
 
 def get_array_from_env(key)
-  JSON.parse(ENV[key]) rescue []
+  JSON.parse(ENV[key])
+rescue StandardError
+  []
 end
 
 repo                  = ENV.fetch("REPO", "")

--- a/lib/run.rb
+++ b/lib/run.rb
@@ -8,10 +8,15 @@ require "json"
 require "bot"
 require "configuration/jira"
 
+def get_array_from_env(key)
+  JSON.parse(ENV[key]) rescue []
+end
+
 repo                  = ENV.fetch("REPO", "")
 action                = ENV.fetch("ACTION", "")
 title                 = ENV.fetch("PR_TITLE", "")
 pr_number             = ENV.fetch("PR_NUMBER", "")
+pr_labels             = get_array_from_env("PR_LABELS")
 author                = ENV.fetch("AUTHOR", "")
 
 comment               = ENV.fetch("COMMENT_BODY", "")
@@ -58,7 +63,7 @@ begin
   if pull_request_comment?(action, title, comment, pr_number, author, comment_id)
     bot.handle_comment(action: action, title: title, comment: comment, pr_number: pr_number, author: author, comment_id: comment_id)
   elsif pull_request?(action, title, pr_number)
-    bot.handle_pull_request(action: action, title: title, pr_number: pr_number)
+    bot.handle_pull_request(action: action, title: title, pr_number: pr_number, pr_labels: pr_labels)
   end
 rescue JIRA::HTTPError => e
   puts "JIRA responded with #{e.response.code}: #{e.response.body}"

--- a/lib/run.rb
+++ b/lib/run.rb
@@ -31,12 +31,12 @@ Octokit.configure do |c|
   c.password = ENV.fetch("GITHUB_PASSWORD")
 end
 
-def issue_comment?(action, title, comment, pr_number, author, comment_id)
-  !action.empty? && !title.empty? && !comment.empty? && !pr_number.empty? && !author.empty? && !comment_id.empty?
+def pull_request_comment?(action, title, comment, pr_number, author, comment_id)
+  pull_request?(action, title, pr_number) && comment.present? && author.present? && comment_id.present?
 end
 
 def pull_request?(action, title, pr_number)
-  !action.empty? && !title.empty? && !pr_number.empty?
+  action.present? && title.present? && pr_number.present?
 end
 
 jira_configuration = Configuration::Jira.new(
@@ -55,7 +55,7 @@ bot = Bot.new(
 )
 
 begin
-  if issue_comment?(action, title, comment, pr_number, author, comment_id)
+  if pull_request_comment?(action, title, comment, pr_number, author, comment_id)
     bot.handle_comment(action: action, title: title, comment: comment, pr_number: pr_number, author: author, comment_id: comment_id)
   elsif pull_request?(action, title, pr_number)
     bot.handle_pull_request(action: action, title: title, pr_number: pr_number)

--- a/lib/run.rb
+++ b/lib/run.rb
@@ -10,7 +10,7 @@ require "configuration/jira"
 
 def get_array_from_env(key)
   JSON.parse(ENV[key])
-rescue StandardError
+rescue TypeError
   []
 end
 

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -301,10 +301,20 @@ describe Bot do
     end
 
     context "when linked issue doesn't exist" do
-      it "returns nil" do
+      before do
         allow(Jira::Issue).to receive(:find).and_return nil
+      end
+
+      it "returns nil" do
         expect(Github::Comment).not_to receive(:create)
         expect(handle_pull_request).to eq(nil)
+      end
+
+      it "creates an issue for a 'depfu'-labeled PR and renames the PR" do
+        pr_labels = ["depfu"]
+
+        expect(Jira::Issue).to receive(:create).and_return(double(key: "LIEF-123"))
+        expect(Github::PullRequest).to receive(:update_title)
       end
     end
   end

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -310,11 +310,14 @@ describe Bot do
         expect(handle_pull_request).to eq(nil)
       end
 
-      it "creates an issue for a 'depfu'-labeled PR and renames the PR" do
-        pr_labels = ["depfu"]
+      context "Depfu PR" do
+        let(:pr_labels) { ["depfu"] }
 
-        expect(Jira::Issue).to receive(:create).and_return(double(key: "LIEF-123"))
-        expect(Github::PullRequest).to receive(:update_title)
+        it "creates an issue and renames the PR" do
+          expect(Jira::Issue).to receive(:create).and_return(double(key: "LIEF-123"))
+          expect(Github::PullRequest).to receive(:update_title)
+          subject
+        end
       end
     end
   end

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -15,6 +15,7 @@ describe Bot do
   let(:repo)                    { "foo/bar" }
   let(:author)                  { "jonhue" }
   let(:pr_number)               { 23 }
+  let(:pr_labels)               { ["WIP - work in progress"] }
   let(:comment_id)              { 12345 }
   let(:jira_transition_id)      { nil }
   let(:max_description_chars)   { 600 }
@@ -217,7 +218,7 @@ describe Bot do
   end
 
   describe "#handle_pull_request" do
-    subject(:handle_pull_request) { bot.handle_pull_request(action: "opened", title: title, pr_number: pr_number) }
+    subject(:handle_pull_request) { bot.handle_pull_request(action: "opened", title: title, pr_number: pr_number, pr_labels: pr_labels) }
 
     context "when linked issue exists" do
       it "adds issue URL and description to GitHub when description exists" do
@@ -287,7 +288,7 @@ describe Bot do
 
           expect(Github::Comment).to receive(:create)
           expect(Github::PullRequest).to receive(:update_title).with(repo, pr_number, title)
-          bot.handle_pull_request(action: "opened", title: branch_name_based_title, pr_number: pr_number)
+          bot.handle_pull_request(action: "opened", title: branch_name_based_title, pr_number: pr_number, pr_labels: pr_labels)
         end
       end
 
@@ -295,7 +296,7 @@ describe Bot do
         allow(Jira::Issue)
           .to receive(:find).with(nil).and_raise("One does not simply find a JIRA issue without an ID!")
 
-        bot.handle_pull_request(action: "opened", title: "I don't give an id", pr_number: pr_number)
+        bot.handle_pull_request(action: "opened", title: "I don't give an id", pr_number: pr_number, pr_labels: pr_labels)
       end
     end
 

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -310,13 +310,14 @@ describe Bot do
         expect(handle_pull_request).to eq(nil)
       end
 
-      context "Depfu PR" do
+      context "when Depfu PR" do
         let(:pr_labels) { ["depfu"] }
 
         it "creates an issue and renames the PR" do
           expect(Jira::Issue).to receive(:create).and_return(double(key: "LIEF-123"))
           expect(Github::PullRequest).to receive(:update_title)
-          subject
+
+          handle_pull_request
         end
       end
     end


### PR DESCRIPTION
Ticket description:
With Depfu PRs we often forget to add "QA:" comments - either completely, or we only add it after merging.
When the comment is not added, no Jira issue is created, as the comment triggers the bot to do that.
When the comment is added after merging, the issue gets created, but gets stuck on the "master" lane in Jira.

One solution is to have the bot automatically create a Jira issue if a PR has the "depfu" label.